### PR TITLE
Add the ability to switch between public and private IP Addresses

### DIFF
--- a/lib/terraform_inventory/cli.rb
+++ b/lib/terraform_inventory/cli.rb
@@ -14,6 +14,11 @@ module TerraformInventory
       banner: "resource_selector:host_group",
       desc: "Maps between Terraform resource selector and Ansible host group."
     }
+    option :ip_type, {
+      banner: "public|private",
+      desc: "Whether to use the public or private ip address",
+      default: "public"
+    }
     option :state, {
       banner: "<path to state file>",
       desc: "Path to a Terraform state file.",
@@ -31,9 +36,14 @@ module TerraformInventory
         @ungrouped_resources = @groups[:none] || []
         @groups.delete(:none)
 
+        config = {
+            :ip_type => "#{options[:ip_type]}_ip"
+        }
+
         template(
           "inventory.erb",
-          inventory_path
+          inventory_path,
+          config
         )
       end
     end

--- a/lib/terraform_inventory/version.rb
+++ b/lib/terraform_inventory/version.rb
@@ -1,3 +1,3 @@
 module TerraformInventory
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end

--- a/templates/inventory.erb
+++ b/templates/inventory.erb
@@ -1,6 +1,6 @@
-<% for resource in @ungrouped_resources %><%= resource["public_ip"] %><% end %>
+<% for resource in @ungrouped_resources %><%= resource[config[:ip_type]] %><% end %>
 <% for group_name, resources in @groups %>
 [<%= group_name %>]
-<% for resource in resources %><%= resource["public_ip"] %>
+<% for resource in resources %><%= resource[config[:ip_type]] %>
 <% end %>
 <% end %>


### PR DESCRIPTION
Many providers have both public and private IP Addresses that can
be assigned to instances.

This patch allows you to switch between the two through the use of
the --ip_type flag which can be set to either "public" or "private".

This is especially useful when running in a Virtual Private Cloud
(VPC) inside AWS as all instances inside the VPC usually have a
private address not a public one.

The flag is optional and defaults to "public" so therefore should
not break existing behaviour.
